### PR TITLE
imported message_ids from bot.py

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -20,7 +20,7 @@ Constants takes variables from constants.py in Pebblehost and uses that.
 """
 from constants import *
 from constVariables import *
-from bot import db, cursor
+from bot import db, cursor, message_ids
 
 '''
 Events cog


### PR DESCRIPTION
events.py uses message_ids = {} but its only defined in bot.py. i had to run "from bot import x, x, message_ids" so that it would stay live and usable between files.